### PR TITLE
RF_PROTOCOL_OGNTP broke nrf905 TX frequency

### DIFF
--- a/software/firmware/source/SoftRF/EEPROMHelper.cpp
+++ b/software/firmware/source/SoftRF/EEPROMHelper.cpp
@@ -44,7 +44,7 @@ void EEPROM_setup()
   }
 
   for (int i=0; i<sizeof(eeprom_t); i++) {
-    eeprom_block.raw[i] = EEPROM.read(i);  
+    eeprom_block.raw[i] = EEPROM.read(i);
   }
 
   if (eeprom_block.field.magic != SOFTRF_EEPROM_MAGIC) {
@@ -69,7 +69,7 @@ void EEPROM_defaults()
   eeprom_block.field.magic = SOFTRF_EEPROM_MAGIC;
   eeprom_block.field.version = SOFTRF_EEPROM_VERSION;
   eeprom_block.field.settings.mode = SOFTRF_MODE_NORMAL;
-  eeprom_block.field.settings.rf_protocol = RF_PROTOCOL_OGNTP;
+  eeprom_block.field.settings.rf_protocol = RF_PROTOCOL_LEGACY;
   eeprom_block.field.settings.band = RF_BAND_EU;
   eeprom_block.field.settings.aircraft_type = AIRCRAFT_TYPE_GLIDER;
   eeprom_block.field.settings.txpower = RF_TX_POWER_FULL;
@@ -93,7 +93,7 @@ void EEPROM_defaults()
 void EEPROM_store()
 {
   for (int i=0; i<sizeof(eeprom_t); i++) {
-    EEPROM.write(i, eeprom_block.raw[i]);  
+    EEPROM.write(i, eeprom_block.raw[i]);
   }
 
   EEPROM.commit();


### PR DESCRIPTION
 TX frequency with a fresh nrf905 installation is always 868.4 MHz instead of 868.2MHz, even though protocol used is Legacy for nrf905 (hardcoded, it seems).

The protocol type cannot be changed in the WIFI settings, therefore, the device is locked to this bad state.

Alternatively:
- hardcode protocol to always be LEGACY with nrf905, but then settings would be inconsistent, which is also not nice.

Note:
my editor (Atom) has also corrected some whitespace. Need to find out where to disable that.