### PR TITLE
fix uBlox M8N detection

### DIFF
--- a/software/firmware/source/SoftRF/GNSSHelper.cpp
+++ b/software/firmware/source/SoftRF/GNSSHelper.cpp
@@ -280,7 +280,6 @@ enum ubloxState{ WAIT_SYNC1, WAIT_SYNC2, GET_CLASS, GET_ID, GET_LL, GET_LH, GET_
 ubloxState ubloxProcessDataState = WAIT_SYNC1;
 
 unsigned short ubloxExpectedDataLength;
-unsigned short ubloxDataLength;
 unsigned short ubloxClass, ubloxId;
 unsigned char  ubloxCKA, ubloxCKB;
 
@@ -331,7 +330,6 @@ static int ubloxProcessData(unsigned char data) {
 
 	case GET_LH:
 		ubloxExpectedDataLength += data << 8;
-		ubloxDataLength = 0;
 		GNSS_cnt = 0;
 		ubloxCKA += data;
 		ubloxCKB += ubloxCKA;
@@ -344,8 +342,7 @@ static int ubloxProcessData(unsigned char data) {
 		if (GNSS_cnt < sizeof(GNSSbuf)) {
 			GNSSbuf[GNSS_cnt++] = data;
 		}
-		ubloxDataLength++;
-		if (ubloxDataLength >= ubloxExpectedDataLength) {
+		if ((--ubloxExpectedDataLength) == 0) {
 			ubloxProcessDataState = GET_CKA;
 		}
 		break;

--- a/software/firmware/source/SoftRF/GNSSHelper.cpp
+++ b/software/firmware/source/SoftRF/GNSSHelper.cpp
@@ -442,10 +442,12 @@ static byte GNSS_version() {
             Serial.print(F("INFO: GNSS module FW version: "));
             Serial.println((char *) &GNSSbuf[0]);
 
+#ifdef DO_GNSS_DEBUG
             for(unsigned i = 30 + 10; i < GNSS_cnt; i+=30) {
               Serial.print(F("INFO: GNSS module extension: "));
               Serial.println((char *) &GNSSbuf[i]);
             }
+#endif
 
             if (GNSSbuf[33] == '4')
               rval = GNSS_MODULE_U6;


### PR DESCRIPTION
Ublox Neo M8N "UBX-MON-VER" payload size is 250, don't fit inside GNSSbuf[240].

- update ubloxProcessData for truncate received data instead of discard all.
- add extended version info to boot log

boot log :

19:56:50.272 -> Reset reason: 0
19:56:50.272 -> POWERON_RESET
19:56:50.272 -> Free heap size: 203820
19:56:50.272 -> Vbat power on reset
19:56:50.272 ->
19:56:50.272 -> EEPROM version: 93
19:56:50.272 -> SX1276 RFIC is detected.
19:56:50.412 -> WARNING! Barometric pressure sensor is NOT detected.
19:56:50.412 -> INFO: TTGO T-Beam GPS module (rev. 05) is detected.
19:56:50.412 -> Flash memory ID: EF4016
19:56:50.833 -> INFO: GNSS module HW version: 00080000
19:56:50.833 -> INFO: GNSS module FW version: EXT CORE 3.01 (107900)
19:56:50.833 -> INFO: GNSS module extension: ROM BASE 3.01 (107888)
19:56:50.833 -> INFO: GNSS module extension: FWVER=SPG 3.01
19:56:50.833 -> INFO: GNSS module extension: PROTVER=18.00
19:56:50.833 -> INFO: GNSS module extension: MOD=NEO-M8N-0
19:56:50.833 -> INFO: GNSS module extension: FIS=0xEF4015 (200037)
19:56:50.833 -> INFO: GNSS module extension: GPS;GLO;GAL;BDS
19:56:50.833 -> INFO: GNSS module extension: SBAS;IMES;QZSS
19:56:51.208 -> Hostname: SoftRF-b99fcc
19:56:51.208 -> Wait for WiFi connection.
19:56:51.208 -> ....................
19:57:01.223 -> Can not connect to WiFi station. Go into AP mode.
19:57:01.270 -> Setting soft-AP configuration ... Ready
19:57:01.270 -> Setting soft-AP ... Ready
19:57:01.270 -> IP address: 192.168.1.1
19:57:01.270 -> UDP server has started at port: 12389
19:57:02.627 -> HTTP server has started at port: 80