### PR TITLE
Enable NMEA GSV sentence for Dongle (+ potentially SBAS)

### DIFF
--- a/software/firmware/source/SoftRF/Platform_STM32.cpp
+++ b/software/firmware/source/SoftRF/Platform_STM32.cpp
@@ -411,8 +411,8 @@ static void STM32_swSer_begin(unsigned long baud)
   /* Idle */
   // swSer.write("@GSTP\r\n");      delay(250);
 
-  /* GGA + GSA + RMC */
-  swSer.write("@BSSL 0x25\r\n"); delay(250);
+  /* GGA + GSA + GSV + RMC */
+  swSer.write("@BSSL 0x2D\r\n"); delay(250);
   /* GPS + GLONASS */
   swSer.write("@GNS 0x3\r\n");   delay(250);
 #if SOC_GPIO_PIN_GNSS_PPS != SOC_UNUSED_PIN


### PR DESCRIPTION
Allows Stratux-EU to show GPS information.
Optionally, we could also enable SBAS (set `@GNS` to `0x7`).
I've tried it and it seems to work very well:
![grafik](https://user-images.githubusercontent.com/1858945/82137640-3c82d400-981a-11ea-8df8-722c3a7719ff.png)

Any thoughts?