### PR TITLE
Update Protocol_Legacy.cpp to ignore own ID as conflicting traffic.

### DIFF
--- a/software/firmware/source/SoftRF/Protocol_Legacy.cpp
+++ b/software/firmware/source/SoftRF/Protocol_Legacy.cpp
@@ -140,6 +140,11 @@ bool legacy_decode(void *legacy_pkt, ufo_t *this_aircraft, ufo_t *fop) {
         }
         return false;
     }
+  
+    /* ignore this device own (relayed) packets */
+    if (pkt->addr == this_aircraft->addr) {
+      return false;
+    }
 
     int32_t round_lat = (int32_t) (ref_lat * 1e7) >> 7;
     int32_t lat = (pkt->lat - round_lat) % (uint32_t) 0x080000;


### PR DESCRIPTION
Fixes own ID being received as conflicting traffic - same as for protocol OGNTP

I tried this fix with some additional debugging code. Own ID pakets were correctly identified and discarded. Debug log available on request.

As lyusupov chose to ignore my issue I hope for all other users he will not ignore the fix.