### PR TITLE
Make Deivce ID 6 characters by enabling leading zero.

### DIFF
--- a/software/firmware/source/SoftRF/WebHelper.cpp
+++ b/software/firmware/source/SoftRF/WebHelper.cpp
@@ -594,7 +594,7 @@ void handleRoot() {
   <!-- <td align=right><img src='/logo.png'></td> --></tr>\
  </table>\
  <table width=100%%>\
-  <tr><th align=left>Device Id</th><td align=right>%X</td></tr>\
+  <tr><th align=left>Device Id</th><td align=right>%06X</td></tr>\
   <tr><th align=left>Software Version</th><td align=right>%s&nbsp;&nbsp;%s</td></tr>"
 #if !defined(ENABLE_AHRS)
  "</table><table width=100%%>\


### PR DESCRIPTION
To register on OGN Dvices database, device ID must be 6 characters.