### PR TITLE
Ignore if the received packet is myself.

### DIFF
--- a/software/firmware/source/SoftRF/TrafficHelper.cpp
+++ b/software/firmware/source/SoftRF/TrafficHelper.cpp
@@ -155,6 +155,10 @@ void ParseData()
 
     if (protocol_decode && (*protocol_decode)((void *) RxBuffer, &ThisAircraft, &fo)) {
 
+      /* ignore if the received packet is from myself. */
+      if (fo.addr == ThisAircraft.addr)
+        return;
+
       fo.rssi = RF_last_rssi;
 
       for (int i=0; i < MAX_TRACKING_OBJECTS; i++) {


### PR DESCRIPTION
The problem which this fix solves makes Prime MK2
useless because XCSoar always reports Urgent
traffic warning which is myself and ignore a really
danger traffic nearby.

This fix solves the same problem the pull request #90
wants to fix, but in ParseData().

I found this problem is in 1.0-rc8.

Signed-off-by: caz yokoyama <caz@caztech.com>