### PR TITLE
detect and delete double IDs

### DIFF
--- a/software/firmware/source/SoftRF/TrafficHelper.cpp
+++ b/software/firmware/source/SoftRF/TrafficHelper.cpp
@@ -154,10 +154,11 @@ void ParseData()
     }
 
     if (protocol_decode && (*protocol_decode)((void *) RxBuffer, &ThisAircraft, &fo)) {
+      int i;
 
       fo.rssi = RF_last_rssi;
 
-      for (int i=0; i < MAX_TRACKING_OBJECTS; i++) {
+      for (i = 0; i < MAX_TRACKING_OBJECTS; i++) {
 
         if (Container[i].addr == fo.addr) {
           Container[i] = fo;
@@ -170,6 +171,12 @@ void ParseData()
             break;
           }
         }
+      }
+
+      /* detect and delte double IDs */
+      while (++i < MAX_TRACKING_OBJECTS) {
+        if (Container[i].addr == fo.addr)
+          Container[i] = EmptyFO;
       }
     }
 }


### PR DESCRIPTION
We have 2 traffics which have the same IDs from time to
time as FlyingBird22 reported in
https://gitter.im/FlyingBird22. It is caused by
"the newly received aircraft information is stored in the
slot which is older than ENTRY_EXPIRATION_TIME".

Let's assume the aircraft A is recorded in slot 7.
The aircraft A transmits its new location. The new location
may be recorded in slot 2 which is expired and used to have
aircraft B. Now the same aircraft exist in slot 2 and 7.

Signed-off-by: caz yokoyama <caz@caztech.com>