### PR TITLE
Added configuration parameter AircraftID to use for RF transmission only. Enables use of ICAO 32bit ID for Legacy protocoll use. 

### DIFF
--- a/software/firmware/source/SoftRF/SoftRF.ino
+++ b/software/firmware/source/SoftRF/SoftRF.ino
@@ -158,9 +158,14 @@ void setup()
   EEPROM_setup();
 
   SoC->Button_setup();
-
-  ThisAircraft.addr = SoC->getChipId() & 0x00FFFFFF;
-
+  if (settings->AircraftID == 0x00)
+  {
+    ThisAircraft.addr = SoC->getChipId() & 0x00FFFFFF;
+  }
+  else
+  {
+    ThisAircraft.addr = settings->AircraftID;
+  }
   hw_info.rf = RF_setup();
 
   delay(100);

--- a/software/firmware/source/SoftRF/src/driver/EEPROM.cpp
+++ b/software/firmware/source/SoftRF/src/driver/EEPROM.cpp
@@ -114,7 +114,7 @@ void EEPROM_defaults()
   eeprom_block.field.settings.no_track   = false;
   eeprom_block.field.settings.power_save = POWER_SAVE_NONE;
   eeprom_block.field.settings.freq_corr  = 0;
-  eeprom_block.field.settings.AircraftID  = 0x003FF2B2;
+  eeprom_block.field.settings.AircraftID  = 0x00;
 }
 
 void EEPROM_store()

--- a/software/firmware/source/SoftRF/src/driver/EEPROM.cpp
+++ b/software/firmware/source/SoftRF/src/driver/EEPROM.cpp
@@ -114,6 +114,7 @@ void EEPROM_defaults()
   eeprom_block.field.settings.no_track   = false;
   eeprom_block.field.settings.power_save = POWER_SAVE_NONE;
   eeprom_block.field.settings.freq_corr  = 0;
+  eeprom_block.field.settings.AircraftID  = 0x003FF2B2;
 }
 
 void EEPROM_store()

--- a/software/firmware/source/SoftRF/src/driver/EEPROM.h
+++ b/software/firmware/source/SoftRF/src/driver/EEPROM.h
@@ -30,7 +30,8 @@
 #endif /* EXCLUDE_EEPROM */
 
 #define SOFTRF_EEPROM_MAGIC   0xBABADEDA
-#define SOFTRF_EEPROM_VERSION 0x0000005F
+//#define SOFTRF_EEPROM_VERSION 0x0000005F
+#define SOFTRF_EEPROM_VERSION 0x00000060
 
 typedef struct Settings {
     uint8_t  mode;
@@ -61,10 +62,10 @@ typedef struct Settings {
     uint8_t  power_save;
     int8_t   freq_corr; /* +/-, kHz */
     uint8_t  resvd23456;
-    uint8_t  resvd7;
-    uint8_t  resvd8;
-    uint8_t  resvd9;
-    uint8_t  resvd10;
+    uint32_t  AircraftID;
+//    uint8_t  resvd8;
+//    uint8_t  resvd9;
+//    uint8_t  resvd10;
     uint8_t  resvd11;
     uint8_t  resvd12;
     uint8_t  resvd13;

--- a/software/firmware/source/SoftRF/src/ui/Web.cpp
+++ b/software/firmware/source/SoftRF/src/ui/Web.cpp
@@ -127,7 +127,7 @@ Copyright (C) 2015-2021 &nbsp;&nbsp;&nbsp; Linar Yusupov\
 
 void handleSettings() {
 
-  size_t size = 5020;
+  size_t size = 5420;
   char *offset;
   size_t len = 0;
   char *Settings_temp = (char *) malloc(size);
@@ -251,6 +251,12 @@ void handleSettings() {
 </td>\
 </tr>\
 <tr>\
+<th align=left>AircraftID (ICAO-HEX, 0=DevID)</th>\
+<td align=right>\
+<INPUT  type='string' name='AircraftID' size='7' maxlength='6' value='%6x'>\
+</td>\
+</tr>\
+<tr>\
 <th align=left>Alarm trigger</th>\
 <td align=right>\
 <select name='alarm'>\
@@ -310,6 +316,7 @@ void handleSettings() {
   (settings->aircraft_type == AIRCRAFT_TYPE_PARAGLIDER ? "selected" : ""),  AIRCRAFT_TYPE_PARAGLIDER,
   (settings->aircraft_type == AIRCRAFT_TYPE_BALLOON ? "selected" : ""),  AIRCRAFT_TYPE_BALLOON,
   (settings->aircraft_type == AIRCRAFT_TYPE_STATIC ? "selected" : ""),  AIRCRAFT_TYPE_STATIC,
+  settings->AircraftID,
   (settings->alarm == TRAFFIC_ALARM_NONE ? "selected" : ""),  TRAFFIC_ALARM_NONE,
   (settings->alarm == TRAFFIC_ALARM_DISTANCE ? "selected" : ""),  TRAFFIC_ALARM_DISTANCE,
   (settings->alarm == TRAFFIC_ALARM_VECTOR ? "selected" : ""),  TRAFFIC_ALARM_VECTOR,
@@ -541,7 +548,9 @@ void handleSettings() {
     size -= len;
   }
 
-  /* Common part 7 */
+
+ 
+  /* Common part 8 */
   snprintf_P ( offset, size,
     PSTR("\
 </table>\
@@ -715,6 +724,13 @@ void handleInput() {
       settings->power_save = server.arg(i).toInt();
     } else if (server.argName(i).equals("rfc")) {
       settings->freq_corr = server.arg(i).toInt();
+    } else if (server.argName(i).equals("AircraftID")) {
+      String AircraftID;
+      AircraftID=server.arg(i);	
+      char cAircraftID[7];
+      AircraftID.toCharArray(cAircraftID, 7);
+
+      settings->AircraftID = strtoul(cAircraftID, 0, 16);
     }
   }
   snprintf_P ( Input_temp, 1600,
@@ -731,6 +747,7 @@ PSTR("<html>\
 <tr><th align=left>Protocol</th><td align=right>%d</td></tr>\
 <tr><th align=left>Band</th><td align=right>%d</td></tr>\
 <tr><th align=left>Aircraft type</th><td align=right>%d</td></tr>\
+<tr><th align=left>AircraftID</th><td align=right>%d</td></tr>\
 <tr><th align=left>Alarm trigger</th><td align=right>%d</td></tr>\
 <tr><th align=left>Tx Power</th><td align=right>%d</td></tr>\
 <tr><th align=left>Volume</th><td align=right>%d</td></tr>\
@@ -753,7 +770,7 @@ PSTR("<html>\
 </body>\
 </html>"),
   settings->mode, settings->rf_protocol, settings->band,
-  settings->aircraft_type, settings->alarm, settings->txpower,
+  settings->aircraft_type, settings->AircraftID, settings->alarm, settings->txpower,
   settings->volume, settings->pointer, settings->bluetooth,
   BOOL_STR(settings->nmea_g), BOOL_STR(settings->nmea_p),
   BOOL_STR(settings->nmea_l), BOOL_STR(settings->nmea_s),


### PR DESCRIPTION
I added a configuration parameter AircraftID to enable use of ICAO 32bit ID for Legacy protocoll. If You have a transponder, and a SoftRF using either OGN or Legacy protocoll you would want to avoid double targets. If that parameter is set to 0 (which is the default on update due to reinit of EEPROM) the DeviceID is used. 
Consequentially a modification of the settings page has been done to enable the change.