### PR TITLE
Prime MkII/T-Beam: Enable alarm sound on Murata 4kHz piezo electric speaker.

### DIFF
--- a/software/firmware/source/SoftRF/src/driver/Sound.h
+++ b/software/firmware/source/SoftRF/src/driver/Sound.h
@@ -19,7 +19,8 @@
 #ifndef SOUNDHELPER_H
 #define SOUNDHELPER_H
 
-#define ALARM_TONE_HZ     1040
+#define ALARM_TONE_HZ     (hw_info.model == SOFTRF_MODEL_PRIME_MK2 ? \
+						   4000 : 1040)
 #define ALARM_TONE_MS     1000
 
 enum

--- a/software/firmware/source/SoftRF/src/platform/ESP32.h
+++ b/software/firmware/source/SoftRF/src/platform/ESP32.h
@@ -102,7 +102,7 @@ extern Adafruit_NeoPixel strip;
                                   SOC_UNUSED_PIN))
 
 #define SOC_GPIO_PIN_BUZZER   (hw_info.model != SOFTRF_MODEL_PRIME_MK2 ?\
-                                13 : SOC_UNUSED_PIN)
+                                13 : 14)
 
 /* SPI (does match Heltec & TTGO LoRa32 pins mapping) */
 #define SOC_GPIO_PIN_MOSI       27


### PR DESCRIPTION
It connects to GPIO14 and GND.
Signed-off-by: Caz Yokoyama <caz@caztech.com>

youtube video will be later.